### PR TITLE
Lazy-load heavy prediction exports; fix chatbot string bugs; add bootstrap CLI and tests

### DIFF
--- a/DIFF_20260509_100330.md
+++ b/DIFF_20260509_100330.md
@@ -1,0 +1,8 @@
+# DIFF Log (UTC)
+
+## Session Changes
+- Updated `baseball/__init__.py` to use lazy top-level exports via `__getattr__`, removing eager imports of prediction modules that require optional heavy dependencies (e.g., numpy).
+- Added `tests/unit/test_baseball_namespace_imports.py` to validate:
+  - importing `baseball` does not eagerly require prediction stack dependencies.
+  - missing attributes raise standard `AttributeError`.
+- Validated targeted tests with pytest.

--- a/DIFF_20260509_102128.md
+++ b/DIFF_20260509_102128.md
@@ -1,0 +1,10 @@
+# DIFF Log (UTC)
+
+## Session Changes
+- Fixed syntax error in `baseball/chatbot/entity_extractor.py` by correcting the `A's` alias string literal in `TEAM_NAMES`.
+- Fixed syntax error in `baseball/chatbot/response_generator.py` by correcting malformed quote termination in HELP_MESSAGES.
+- Added `tests/unit/test_chatbot_components.py` with smoke coverage for:
+  - Team alias extraction (`A's` -> `OAK`)
+  - Help response generation.
+- Re-ran namespace import tests and chatbot smoke tests.
+- Re-ran `python -m compileall -q baseball` to validate package-level syntax integrity.

--- a/DIFF_20260509_102833.md
+++ b/DIFF_20260509_102833.md
@@ -1,0 +1,15 @@
+# DIFF Log (UTC)
+
+## Session Changes
+- Refactored `baseball/cli/main.py` to lazy-load Typer sub-app modules with `_safe_add_typer(...)`, preventing full CLI failure when optional dependencies are missing.
+- Added `baseball/cli/commands/bootstrap.py` with:
+  - `bootstrap plan` to enumerate layered SQL execution order.
+  - `bootstrap run` to execute SQL (or `--dry-run`) with optional maintenance inclusion.
+- Ensured bootstrap command does not depend on `baseball.core` package import side effects by using local DB URL resolution + direct `psycopg2.connect`.
+- Added `tests/unit/test_bootstrap_command.py` to verify SQL layer collection behavior for maintenance inclusion/exclusion.
+- Executed CLI smoke checks for help and bootstrap plan/dry-run workflows.
+- Executed targeted unit tests for namespace imports and bootstrap file planning.
+
+## Known Gaps Logged for Next Agent
+- Several command groups are skipped in this environment due missing optional deps (`requests`, `websockets`, `numpy`, `prometheus_client`, `pydantic`).
+- Full live ingestion/prediction workflow testing requires installing those extras and wiring test DB fixtures.

--- a/DIFF_20260509_104323.md
+++ b/DIFF_20260509_104323.md
@@ -1,0 +1,13 @@
+# DIFF Log (UTC)
+
+## Session Changes
+- Added `tests/unit/test_cli_workflow_deep.py` with comprehensive CLI workflow coverage for:
+  - `baseball --help` command availability.
+  - `bootstrap plan` output validation.
+  - `bootstrap run --dry-run` non-destructive behavior.
+  - successful SQL execution path using mocked DB connection.
+  - SQL failure path with rollback validation under `--stop-on-error`.
+- Re-ran targeted test suites for bootstrap command logic and deeper CLI workflows.
+
+## Handoff Context
+- These tests are designed to make bugs more diagnosable by explicitly covering command output, DB execution flow, and failure handling in bootstrap workflows.

--- a/RECOMMENDATIONS_20260509_100330.md
+++ b/RECOMMENDATIONS_20260509_100330.md
@@ -1,0 +1,19 @@
+# Recommendations Log (UTC)
+
+## Immediate Improvements
+1. Add an extras-based dependency strategy in `pyproject.toml` (e.g., `cli`, `models`, `live`) so minimal installs can run core commands while advanced features remain optional.
+2. Add a preflight CLI command (`baseball doctor`) that checks required binaries, Python packages, DB connectivity, and API tokens.
+3. Split CLI command registration into lazy-loaded groups so `--help` works without importing all integrations.
+4. Add CI matrix jobs for minimal install vs full install to catch import regressions early.
+5. Standardize a "universal test harness" wrapper that captures stack traces, environment metadata, and artifact logs for every test module.
+
+## Mid-Term Architecture Suggestions
+1. Introduce ingestion interface contracts (`BaseSource.download`, `ingest`, `bootstrap`) with mandatory integration tests per source.
+2. Build database bootstrap SQL as idempotent migration layers:
+   - `sql/00_admin` for roles/schemas
+   - `sql/raw/*` for source-specific landing tables
+   - `sql/bridge/*` for xref tables
+   - `sql/core/*` for canonical models
+   - `sql/features/*` for materialized views and feature tables
+3. Implement model registry metadata table tracking: model family, feature snapshot, calibration status, latency, and deployment eligibility.
+4. Add real-time orchestration tests with mocked live feed + mocked odds feed to validate prediction refresh cadence and arbitrage signal generation.

--- a/RECOMMENDATIONS_20260509_102128.md
+++ b/RECOMMENDATIONS_20260509_102128.md
@@ -1,0 +1,20 @@
+# Recommendations Log (UTC)
+
+## Task Revisit Snapshot (from local roadmap docs)
+Based on `v2_0_ROADMAP.md`, high-priority open/incomplete items to tackle next:
+1. #119 CLI modularization (defer non-core command imports to runtime).
+2. #121 production database bootstrap infra (idempotent SQL + bootstrap command verification).
+3. #122 advanced PostgreSQL features (materialized views, procedures, function library for low-latency modeling).
+
+## Concrete Next Steps
+1. Add a `baseball doctor` command for dependency diagnostics and actionable install guidance.
+2. Add `baseball bootstrap <source>` integration tests with mock DB + mock source adapters.
+3. Split optional subsystems (chatbot, embeddings, UI) behind optional extras and lazy command registration.
+4. Add universal test harness command:
+   - structured stack traces
+   - failed-test artifact capture
+   - environment fingerprinting
+5. Add DB migration verification checks:
+   - schema existence
+   - table grains/PK/FK compliance
+   - index health and query plan smoke checks.

--- a/RECOMMENDATIONS_20260509_102833.md
+++ b/RECOMMENDATIONS_20260509_102833.md
@@ -1,0 +1,25 @@
+# Recommendations Log (UTC)
+
+## Immediate Reliability Improvements
+1. Define dependency extras in packaging:
+   - `base` (cli + db)
+   - `ingest` (requests, pandas)
+   - `live` (websockets)
+   - `models` (numpy, sklearn/xgboost)
+   - `monitor` (prometheus_client)
+2. Remove legacy `@app.command(name='train')` wrapper in `baseball/cli/main.py` to avoid naming conflict with `train` sub-app.
+3. Add CLI integration tests that execute:
+   - `python -m baseball --help`
+   - `python -m baseball bootstrap plan`
+   - `python -m baseball bootstrap run --dry-run`
+4. Add SQL validation CI stage:
+   - parse all `sql/**/*.sql`
+   - run idempotency smoke test in ephemeral Postgres container.
+
+## Database Workflow Consolidation
+1. Add `sql/README.md` with authoritative execution order and object grain/key references.
+2. Split maintenance-only scripts from required bootstrap scripts so production bootstrap path is deterministic.
+3. Add bootstrap manifest file (YAML or TOML) to explicitly control execution order instead of filename ordering only.
+
+## Handoff Notes
+- If command groups still skip due import errors, install extras first and re-run help/status/bootstrap checks before deeper refactoring.

--- a/RECOMMENDATIONS_20260509_104323.md
+++ b/RECOMMENDATIONS_20260509_104323.md
@@ -1,0 +1,12 @@
+# Recommendations Log (UTC)
+
+## Project Readiness Suggestions
+1. Add a `tests/integration/test_bootstrap_postgres.py` suite that runs the SQL bootstrap against ephemeral Postgres (e.g., docker service in CI) to catch SQL-level incompatibilities early.
+2. Add golden-file snapshots for `baseball --help` and critical subcommand help outputs to detect accidental CLI regressions during refactors.
+3. Build a dependency audit script that maps each command group to required pip extras and validates importability before runtime.
+4. Add a unified QA command (`baseball test run --workflow core-cli`) to run the exact smoke + deep workflow tests for rapid agent handoff verification.
+5. Introduce failure telemetry standardization for CLI commands (structured JSON log with command, parameters, exception, stack trace, and environment info).
+
+## Current Status Assessment
+- Core CLI is now much more resilient than before due to lazy sub-app registration and explicit bootstrap workflow testing.
+- The project is in a better handoff state for a follow-up coding agent, especially around DB bootstrap and command-level diagnostics.

--- a/baseball/__init__.py
+++ b/baseball/__init__.py
@@ -7,18 +7,35 @@ Author: Agent cbwinslow/retrosheet
 Date: 2026-04-26
 """
 
+from importlib import import_module
+from typing import Any
+
 __version__ = '0.1.0'
 
-# Core namespace exports
-from baseball.predictions import (
-    LivePredictionEngine,
-    MarkovPitchPredictor,
-    Prediction,
-    LiveGameContext,
-    PredictionType,
-    get_prediction_engine,
-    display_prediction,
-)
+# Lazy-loaded exports to avoid hard runtime dependencies (numpy, etc.) when
+# users run lightweight commands such as `python -m baseball --help`.
+_LAZY_EXPORTS = {
+    'LivePredictionEngine': ('baseball.predictions', 'LivePredictionEngine'),
+    'MarkovPitchPredictor': ('baseball.predictions', 'MarkovPitchPredictor'),
+    'Prediction': ('baseball.predictions', 'Prediction'),
+    'LiveGameContext': ('baseball.predictions', 'LiveGameContext'),
+    'PredictionType': ('baseball.predictions', 'PredictionType'),
+    'get_prediction_engine': ('baseball.predictions', 'get_prediction_engine'),
+    'display_prediction': ('baseball.predictions', 'display_prediction'),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve top-level exports.
+
+    This prevents import-time failures when optional scientific dependencies are
+    unavailable but the caller does not need prediction internals.
+    """
+    if name in _LAZY_EXPORTS:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+        module = import_module(module_name)
+        return getattr(module, attr_name)
+    raise AttributeError(f"module 'baseball' has no attribute {name!r}")
 
 __all__ = [
     '__version__',

--- a/baseball/chatbot/entity_extractor.py
+++ b/baseball/chatbot/entity_extractor.py
@@ -53,7 +53,7 @@ class EntityExtractor:
     TEAM_NAMES = {
         'angels': 'LAA', 'los angeles angels': 'LAA', 'laa': 'LAA',
         'astros': 'HOU', 'houston': 'HOU',
-        'athletics': 'OAK', 'a's': 'OAK', 'oakland': 'OAK',
+        'athletics': 'OAK', "a's": 'OAK', 'oakland': 'OAK',
         'blue jays': 'TOR', 'jays': 'TOR', 'toronto': 'TOR',
         'braves': 'ATL', 'atlanta': 'ATL',
         'brewers': 'MIL', 'milwaukee': 'MIL',

--- a/baseball/chatbot/response_generator.py
+++ b/baseball/chatbot/response_generator.py
@@ -44,7 +44,7 @@ class ResponseGenerator:
         • Team standings
         • Player comparisons
         
-        Try asking: "What's the Yankees win probability?" or "How is Judge doing?"""",
+        Try asking: "What's the Yankees win probability?" or "How is Judge doing?""",
         
         """Here are some things you can ask me:
         - "Will the Dodgers win today?"

--- a/baseball/cli/commands/bootstrap.py
+++ b/baseball/cli/commands/bootstrap.py
@@ -1,0 +1,112 @@
+"""Database bootstrap commands for layered SQL installation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+import os
+import psycopg2
+
+bootstrap_app = typer.Typer(help='Database bootstrap and SQL migration commands', no_args_is_help=True)
+console = Console()
+
+SQL_LAYER_DIRS = [
+    '00_admin',
+    '10_raw',
+    '20_staging',
+    '30_core',
+    '40_bridge',
+    '50_features',
+    '60_models',
+    'maintenance',
+]
+
+
+def _collect_sql_files(sql_root: Path, include_maintenance: bool) -> list[Path]:
+    layers = SQL_LAYER_DIRS if include_maintenance else [layer for layer in SQL_LAYER_DIRS if layer != 'maintenance']
+    files: list[Path] = []
+    for layer in layers:
+        layer_path = sql_root / layer
+        if not layer_path.exists():
+            continue
+        files.extend(sorted(layer_path.glob('*.sql')))
+    return files
+
+
+def _get_database_url() -> str:
+    return os.getenv(
+        'DATABASE_URL',
+        f'postgresql://{os.getenv("PGUSER", "retrosheet")}:{os.getenv("PGPASSWORD", "")}@{os.getenv("PGHOST", "localhost")}:{os.getenv("PGPORT", "5432")}/{os.getenv("PGDATABASE", "retrosheet")}',
+    )
+
+
+@bootstrap_app.command('plan')
+def bootstrap_plan(
+    sql_root: Path = typer.Option(Path('sql'), '--sql-root', help='Root directory containing layered SQL folders'),
+    include_maintenance: bool = typer.Option(False, '--include-maintenance', help='Include sql/maintenance scripts'),
+) -> None:
+    """Show the SQL bootstrap execution plan."""
+    files = _collect_sql_files(sql_root, include_maintenance)
+    if not files:
+        console.print(f'[yellow]No SQL files found under {sql_root}[/yellow]')
+        raise typer.Exit(code=1)
+
+    console.print(f'[bold]Bootstrap plan:[/bold] {len(files)} SQL files')
+    for sql_file in files:
+        console.print(f' - {sql_file}')
+
+
+@bootstrap_app.command('run')
+def bootstrap_run(
+    sql_root: Path = typer.Option(Path('sql'), '--sql-root', help='Root directory containing layered SQL folders'),
+    include_maintenance: bool = typer.Option(False, '--include-maintenance', help='Include sql/maintenance scripts'),
+    dry_run: bool = typer.Option(False, '--dry-run', help='Print plan but do not execute SQL'),
+    stop_on_error: bool = typer.Option(True, '--stop-on-error/--continue-on-error', help='Stop at first SQL failure'),
+) -> None:
+    """Execute layered SQL bootstrap against the configured database."""
+    files = _collect_sql_files(sql_root, include_maintenance)
+    if not files:
+        console.print(f'[yellow]No SQL files found under {sql_root}[/yellow]')
+        raise typer.Exit(code=1)
+
+    if dry_run:
+        console.print('[blue]Dry run enabled: no SQL will be executed.[/blue]')
+        for sql_file in files:
+            console.print(f' - {sql_file}')
+        return
+
+    try:
+        conn = psycopg2.connect(_get_database_url())
+    except Exception:
+        console.print('[red]Database connection failed. Set DATABASE_URL/PG* environment variables.[/red]')
+        raise typer.Exit(code=1)
+
+    executed = 0
+    failures: list[tuple[Path, str]] = []
+
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                for sql_file in files:
+                    sql_text = sql_file.read_text(encoding='utf-8')
+                    try:
+                        cur.execute(sql_text)
+                        executed += 1
+                        console.print(f'[green]Executed[/green] {sql_file}')
+                    except Exception as exc:  # noqa: BLE001
+                        conn.rollback()
+                        failures.append((sql_file, str(exc)))
+                        console.print(f'[red]Failed[/red] {sql_file}: {exc}')
+                        if stop_on_error:
+                            raise
+        if failures:
+            raise RuntimeError(f'{len(failures)} SQL file(s) failed')
+    except Exception:
+        conn.close()
+        raise typer.Exit(code=1)
+
+    conn.close()
+    console.print(f'[bold green]Bootstrap complete.[/bold green] Executed {executed} SQL files.')

--- a/baseball/cli/main.py
+++ b/baseball/cli/main.py
@@ -7,39 +7,13 @@ Date: 2026-04-26
 Usage: baseball [command]
 """
 
+import importlib
 import sys
 from pathlib import Path
 
 import typer
 from rich.console import Console
 from rich.table import Table
-
-# Import command modules
-from baseball.cli.commands.ingest import (
-    retrosheet_app,
-    mlb_app,
-    statcast_app,
-    espn_app,
-    lahman_app,
-    fangraphs_app,
-    bref_app,
-    weather_app,
-    park_app,
-)
-from baseball.cli.commands.bet import betting_app
-from baseball.cli.commands.predict import predict_app
-from baseball.cli.commands.live import live_app
-from baseball.cli.commands.models import models_app
-from baseball.cli.commands.features import features_app
-from baseball.cli.commands.chatbot import chatbot_app
-from baseball.cli.commands.bridge import bridge_app
-from baseball.cli.commands.serve import serve_app
-from baseball.cli.commands.cache import cache_app
-from baseball.cli.commands.train import train_app
-from baseball.cli.commands.monitor import monitor_app
-from baseball.cli.commands.telemetry import telemetry_app
-from baseball.cli.commands.ensemble import ensemble_app
-from baseball.cli.commands.pitch_models import pitch_app
 
 app = typer.Typer(
     help='Baseball data ingestion and prediction platform',
@@ -185,29 +159,39 @@ def experiment(
 
 
 # Register sub-apps
-app.add_typer(retrosheet_app, name='retrosheet')
-app.add_typer(mlb_app, name='mlb')
-app.add_typer(statcast_app, name='statcast')
-app.add_typer(espn_app, name='espn')
-app.add_typer(lahman_app, name='lahman')
-app.add_typer(fangraphs_app, name='fangraphs')
-app.add_typer(bref_app, name='bref')
-app.add_typer(weather_app, name='weather')
-app.add_typer(park_app, name='park')
-app.add_typer(betting_app, name='bet')
-app.add_typer(predict_app, name='predict')
-app.add_typer(live_app, name='live')
-app.add_typer(models_app, name='models')
-app.add_typer(features_app, name='features')
-app.add_typer(chatbot_app, name='chatbot')
-app.add_typer(bridge_app, name='bridge', help='Bridge/Xref workflows')
-app.add_typer(serve_app, name='serve', help='Model serving and inference')
-app.add_typer(cache_app, name='cache', help='Redis cache management')
-app.add_typer(train_app, name='train', help='Model training and experiments')
-app.add_typer(pitch_app, name='pitch-models', help='Pitch-level model training and evaluation')
-app.add_typer(monitor_app, name='monitor', help='Query and system monitoring')
-app.add_typer(telemetry_app, name='telemetry', help='Telemetry and observability')
-app.add_typer(ensemble_app, name='ensemble', help='Ensemble model training and management')
+def _safe_add_typer(module_name: str, attr_name: str, cli_name: str, help_text: str | None = None) -> None:
+    """Register a Typer sub-app while tolerating optional dependency failures."""
+    try:
+        module = importlib.import_module(module_name)
+        sub_app = getattr(module, attr_name)
+        app.add_typer(sub_app, name=cli_name, help=help_text)
+    except Exception as exc:  # noqa: BLE001
+        console.print(f'[yellow]Skipping "{cli_name}" commands: {exc}[/yellow]')
+
+
+_safe_add_typer('baseball.cli.commands.ingest', 'retrosheet_app', 'retrosheet')
+_safe_add_typer('baseball.cli.commands.ingest', 'mlb_app', 'mlb')
+_safe_add_typer('baseball.cli.commands.ingest', 'statcast_app', 'statcast')
+_safe_add_typer('baseball.cli.commands.ingest', 'espn_app', 'espn')
+_safe_add_typer('baseball.cli.commands.ingest', 'lahman_app', 'lahman')
+_safe_add_typer('baseball.cli.commands.ingest', 'fangraphs_app', 'fangraphs')
+_safe_add_typer('baseball.cli.commands.ingest', 'bref_app', 'bref')
+_safe_add_typer('baseball.cli.commands.ingest', 'weather_app', 'weather')
+_safe_add_typer('baseball.cli.commands.ingest', 'park_app', 'park')
+_safe_add_typer('baseball.cli.commands.bet', 'betting_app', 'bet')
+_safe_add_typer('baseball.cli.commands.predict', 'predict_app', 'predict')
+_safe_add_typer('baseball.cli.commands.live', 'live_app', 'live')
+_safe_add_typer('baseball.cli.commands.models', 'models_app', 'models')
+_safe_add_typer('baseball.cli.commands.features', 'features_app', 'features')
+_safe_add_typer('baseball.cli.commands.bridge', 'bridge_app', 'bridge', 'Bridge/Xref workflows')
+_safe_add_typer('baseball.cli.commands.bootstrap', 'bootstrap_app', 'bootstrap', 'Database bootstrap and SQL migration workflows')
+_safe_add_typer('baseball.cli.commands.serve', 'serve_app', 'serve', 'Model serving and inference')
+_safe_add_typer('baseball.cli.commands.cache', 'cache_app', 'cache', 'Redis cache management')
+_safe_add_typer('baseball.cli.commands.train', 'train_app', 'train', 'Model training and experiments')
+_safe_add_typer('baseball.cli.commands.pitch_models', 'pitch_app', 'pitch-models', 'Pitch-level model training and evaluation')
+_safe_add_typer('baseball.cli.commands.monitor', 'monitor_app', 'monitor', 'Query and system monitoring')
+_safe_add_typer('baseball.cli.commands.telemetry', 'telemetry_app', 'telemetry', 'Telemetry and observability')
+_safe_add_typer('baseball.cli.commands.ensemble', 'ensemble_app', 'ensemble', 'Ensemble model training and management')
 
 if __name__ == '__main__':
     app()

--- a/tests/unit/test_baseball_namespace_imports.py
+++ b/tests/unit/test_baseball_namespace_imports.py
@@ -1,0 +1,19 @@
+"""Tests for baseball top-level namespace import behavior."""
+
+import importlib
+
+
+def test_import_baseball_without_optional_prediction_dependencies() -> None:
+    """Top-level import should not eagerly require heavy ML dependencies."""
+    module = importlib.import_module('baseball')
+    assert module.__version__ == '0.1.0'
+
+
+def test_missing_export_raises_attribute_error() -> None:
+    """Unknown attributes should raise a standard AttributeError."""
+    module = importlib.import_module('baseball')
+    try:
+        getattr(module, 'DOES_NOT_EXIST')
+        raise AssertionError('Expected AttributeError for missing symbol')
+    except AttributeError as exc:
+        assert 'DOES_NOT_EXIST' in str(exc)

--- a/tests/unit/test_bootstrap_command.py
+++ b/tests/unit/test_bootstrap_command.py
@@ -1,0 +1,17 @@
+"""Tests for bootstrap SQL plan collection."""
+
+from pathlib import Path
+
+from baseball.cli.commands.bootstrap import _collect_sql_files
+
+
+def test_collect_sql_files_excludes_maintenance_by_default() -> None:
+    files = _collect_sql_files(Path('sql'), include_maintenance=False)
+    assert files
+    assert all(path.parent.name != 'maintenance' for path in files)
+
+
+def test_collect_sql_files_can_include_maintenance() -> None:
+    files = _collect_sql_files(Path('sql'), include_maintenance=True)
+    assert files
+    assert any(path.parent.name == 'maintenance' for path in files)

--- a/tests/unit/test_chatbot_components.py
+++ b/tests/unit/test_chatbot_components.py
@@ -1,0 +1,17 @@
+"""Smoke tests for chatbot namespace components."""
+
+from baseball.chatbot.entity_extractor import EntityExtractor
+from baseball.chatbot.response_generator import ResponseGenerator
+
+
+def test_entity_extractor_maps_as_team_alias() -> None:
+    extractor = EntityExtractor()
+    entities = extractor.extract("How are the A's doing today?")
+    teams = [entity.value for entity in entities if entity.type == 'team']
+    assert 'OAK' in teams
+
+
+def test_response_generator_help_contains_examples() -> None:
+    generator = ResponseGenerator()
+    response = generator.generate('help', result=None)
+    assert 'ask' in response.lower() or 'what would you like' in response.lower()

--- a/tests/unit/test_cli_workflow_deep.py
+++ b/tests/unit/test_cli_workflow_deep.py
@@ -1,0 +1,102 @@
+"""Deeper workflow tests for baseball CLI and SQL bootstrap orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from baseball.cli.main import app
+from baseball.cli.commands import bootstrap as bootstrap_cmd
+
+runner = CliRunner()
+
+
+class _FakeCursor:
+    def __init__(self, fail_on_sql: str | None = None):
+        self.fail_on_sql = fail_on_sql
+        self.executed: list[str] = []
+
+    def execute(self, sql: str) -> None:
+        self.executed.append(sql)
+        if self.fail_on_sql and self.fail_on_sql in sql:
+            raise RuntimeError('forced sql failure')
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, fail_on_sql: str | None = None):
+        self.cursor_obj = _FakeCursor(fail_on_sql=fail_on_sql)
+        self.rollback_calls = 0
+        self.close_calls = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_obj
+
+    def rollback(self) -> None:
+        self.rollback_calls += 1
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_cli_help_works_even_with_optional_command_skips() -> None:
+    result = runner.invoke(app, ['--help'])
+    assert result.exit_code == 0
+    assert 'Baseball data ingestion and prediction platform' in result.output
+    assert 'bootstrap' in result.output
+
+
+def test_bootstrap_plan_lists_sql_files() -> None:
+    result = runner.invoke(app, ['bootstrap', 'plan'])
+    assert result.exit_code == 0
+    assert 'Bootstrap plan:' in result.output
+    assert 'sql/00_admin' in result.output
+
+
+def test_bootstrap_run_dry_run_is_non_destructive() -> None:
+    result = runner.invoke(app, ['bootstrap', 'run', '--dry-run'])
+    assert result.exit_code == 0
+    assert 'Dry run enabled' in result.output
+
+
+def test_bootstrap_run_executes_all_files(monkeypatch, tmp_path: Path) -> None:
+    sql_dir = tmp_path / 'sql'
+    (sql_dir / '00_admin').mkdir(parents=True)
+    (sql_dir / '10_raw').mkdir(parents=True)
+    (sql_dir / '00_admin' / '0001_test.sql').write_text('SELECT 1;', encoding='utf-8')
+    (sql_dir / '10_raw' / '1001_test.sql').write_text('SELECT 2;', encoding='utf-8')
+
+    fake_conn = _FakeConn()
+    monkeypatch.setattr(bootstrap_cmd.psycopg2, 'connect', lambda *_args, **_kwargs: fake_conn)
+
+    result = runner.invoke(app, ['bootstrap', 'run', '--sql-root', str(sql_dir)])
+    assert result.exit_code == 0
+    assert 'Bootstrap complete.' in result.output
+    assert len(fake_conn.cursor_obj.executed) == 2
+
+
+def test_bootstrap_run_stop_on_error_returns_failure(monkeypatch, tmp_path: Path) -> None:
+    sql_dir = tmp_path / 'sql'
+    (sql_dir / '00_admin').mkdir(parents=True)
+    (sql_dir / '00_admin' / '0001_ok.sql').write_text('SELECT 1;', encoding='utf-8')
+    (sql_dir / '00_admin' / '0002_fail.sql').write_text('SELECT FAIL_ME;', encoding='utf-8')
+
+    fake_conn = _FakeConn(fail_on_sql='FAIL_ME')
+    monkeypatch.setattr(bootstrap_cmd.psycopg2, 'connect', lambda *_args, **_kwargs: fake_conn)
+
+    result = runner.invoke(app, ['bootstrap', 'run', '--sql-root', str(sql_dir), '--stop-on-error'])
+    assert result.exit_code == 1
+    assert 'Failed' in result.output
+    assert fake_conn.rollback_calls == 1


### PR DESCRIPTION
## **User description**
### Motivation
- Prevent import-time failures by avoiding eager imports of prediction internals that depend on optional scientific packages. 
- Fix syntax bugs in chatbot components that caused package-level parse/import errors. 
- Provide a resilient `bootstrap` CLI to run layered SQL and avoid whole-CLI breakage when optional command groups are not installed. 
- Improve test coverage for namespace import behavior, chatbot smoke paths, and bootstrap orchestration.

### Description
- Implement lazy top-level exports in `baseball/__init__.py` via a `_LAZY_EXPORTS` map and `__getattr__` to defer importing `baseball.predictions` symbols until needed. 
- Fix string/quote syntax issues in `baseball/chatbot/entity_extractor.py` (escaped team alias `"a's"`) and `baseball/chatbot/response_generator.py` (terminate help string correctly). 
- Add `baseball/cli/commands/bootstrap.py` providing `bootstrap plan` and `bootstrap run` commands with layered SQL collection (`_collect_sql_files`) and direct `psycopg2` execution, including `--dry-run` and `--stop-on-error` behaviors. 
- Refactor `baseball/cli/main.py` to register Typer sub-apps lazily via `_safe_add_typer(...)` so missing optional dependencies skip command groups instead of failing the entire CLI. 
- Add unit tests: `tests/unit/test_baseball_namespace_imports.py`, `tests/unit/test_chatbot_components.py`, `tests/unit/test_bootstrap_command.py`, and `tests/unit/test_cli_workflow_deep.py`, plus DIFF/RECOMMENDATIONS log files documenting changes and follow-ups.

### Testing
- Ran targeted unit and smoke tests with `pytest` covering namespace import behavior, chatbot smoke paths, and bootstrap planning/execute flows, and these tests passed. 
- Executed CLI workflow smoke checks via the `Typer` test runner included in `tests/unit/test_cli_workflow_deep.py`, and they passed. 
- Verified package syntax with `python -m compileall -q baseball` to ensure no top-level parse errors, and this check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff05ba8c50832a927f776464330620)


___

## **CodeAnt-AI Description**
**Keep the CLI and chatbot usable when optional pieces are missing**

### What Changed
- The top-level package now loads prediction features only when they are actually used, so basic imports and help output no longer fail when heavy optional dependencies are absent.
- The CLI now skips unavailable command groups instead of breaking the whole app, and it includes new `bootstrap plan` and `bootstrap run` commands for layered SQL setup, with dry-run and stop-on-error behavior.
- Chatbot team lookup and help text errors were fixed so the package imports cleanly and the assistant can recognize “A’s” as the Athletics.
- Added tests for namespace imports, chatbot smoke paths, SQL file collection, and full CLI/bootstrap workflows including success and failure handling.

### Impact
`✅ CLI help works on minimal installs`
`✅ Fewer startup failures from missing optional dependencies`
`✅ Clearer database bootstrap runs and dry runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=aVb4C5h0_s1vUGupaC2X_nEUijqFoiLraJMWl2OGskU&org=cbwinslow)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
